### PR TITLE
Fix typo

### DIFF
--- a/fr/04_Vertex_buffers/02_Buffer_intermédiaire.md
+++ b/fr/04_Vertex_buffers/02_Buffer_intermédiaire.md
@@ -67,7 +67,7 @@ l'utilisation type du buffer. La fonction a deux résultats, elle fonctionne don
 derniers paramètres, dans lesquels elle place les référernces aux objets créés.
 
 Vous pouvez maintenant supprimer la création du buffer et l'allocation de la mémoire de `createVertexBuffer` et
-remplacer tout ça par deux appels à votre nouvelle fonction :
+remplacer tout ça par un appel à votre nouvelle fonction :
 
 ```c++
 void createVertexBuffer() {


### PR DESCRIPTION
L'appel à `createBuffer` n'est fait qu'une seule fois dans `createVertexBuffer` à ce stade du tutoriel.